### PR TITLE
Apply postcss transforms for tagged template css

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ module.exports = function({types: t}) {
   return {
     visitor: {
       TaggedTemplateExpression: function(path, state) {
-        if (path.node.tag.name !== 'csjs') {
+        if (path.node.tag.name !== 'csjs' &&
+            path.node.tag.name !== 'css') {
           return false;
         }
 


### PR DESCRIPTION
Atom will enable the syntax highlighting for css if the tagged template is named `css` (instead of `csjs`).
I know this is kind of out of the scope of this repo, but it's such a minor change that it doesn't seem necessary to keep a separate project just for that.
